### PR TITLE
Add manifest.json version update check

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -29,6 +29,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Check if manifest json version has been updated
+        id: manifest-version-check
+        uses: EndBug/version-check@v2.1.5
+        with:
+          file-name: ./src/manifest.json
+
+      - name: Fail if manifest json version is not updated
+        if: ${{ steps.manifest-version-check.outputs.changed == 'false' }}
+        run: |
+          echo The manifest.json version was not updated. Please update the version and try again.
+          exit 1
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -35,6 +35,15 @@ jobs:
         with:
           file-name: ./src/manifest.json
 
+      - name: Create or update comment if manifest json version is not updated
+        uses: peter-evans/create-or-update-comment@v3
+        if: ${{ steps.manifest-version-check.outputs.changed == 'false' }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ⚠️ The manifest.json version was not updated. Please update the version and try again.
+
       - name: Fail if manifest json version is not updated
         if: ${{ steps.manifest-version-check.outputs.changed == 'false' }}
         run: |


### PR DESCRIPTION
## What has changed and why?
Updated the cicd pipeline to include checks to ensure that the manifest json version was updated and if not it will comment and fail the pr.

## Does this fix an open issue? 
(If yes, please mention the number here)

## Type of change   
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist  
- [x] I have followed the [`CONTRIBUTING` document](https://github.com/ClydeDz/hours-to-days-chrome-extension/blob/main/docs/CONTRIBUTING.md) and have updated the required files.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] I've manually tested this change locally to ensure no errors appear.
