### PR TITLE
Update position of tooltip, allow decimal places in hours per day, and other improvements

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -34,6 +34,7 @@ jobs:
         uses: EndBug/version-check@v2.1.5
         with:
           file-name: ./src/manifest.json
+          diff-search: true
 
       - name: Create or update comment if manifest json version is not updated
         uses: peter-evans/create-or-update-comment@v3

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -100,11 +100,11 @@ jobs:
         with:
           args: zip -qq -r extension.zip src
 
-      # - name: Publish to Chrome store
-      #   uses: Klemensas/chrome-extension-upload-action@v1.3
-      #   with:
-      #     refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
-      #     client-id: ${{ secrets.CHROME_CLIENT_ID }}
-      #     client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
-      #     app-id: ${{ secrets.CHROME_APP_ID }}
-      #     file-name: "./extension.zip"
+      - name: Publish to Chrome store
+        uses: Klemensas/chrome-extension-upload-action@v1.3
+        with:
+          refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          client-id: ${{ secrets.CHROME_CLIENT_ID }}
+          client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
+          app-id: ${{ secrets.CHROME_APP_ID }}
+          file-name: "./extension.zip"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ No worries anymore. With the help of this extension, when you see a value displa
 
 By default, the number of hours per day is set to 8 (in line with most corporate working hours). And by default, the tooltip message will show up for 3 seconds. If you need to change any of these values, you can customize it in the Options page of this extension. Just click on the Hours to Days extension from the top-right extensions group.
 
+Please note, it will work on most websites but it will not work on PDFs.
+
 ## Credits
 
 Developed by [Clyde D'Souza](https://clydedsouza.net/) Please consider [buying me a coffee](https://sponsor.clydedsouza.net/) to support my development endeavors.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,7 +21,7 @@ In other words, the pull request process. When you're ready with your changes, o
 
 - Think of how you can tackle a piece of work in the smallest unit possible. A small unit, in this case, would be something that adds value even though the changes are small. Small changes are easier to review, hence the request to think small where possible.
 - Ensure you've added or updated unit tests. Would your unit test fail if someone was to accidentally modify your code?
-- Update the version number in the [manifest.json file](https://github.com/ClydeDz/hours-to-days-chrome-extension/blob/main/src/manifest.json#L5) and [package.json file](https://github.com/ClydeDz/hours-to-days-chrome-extension/blob/main/package.json#L3). We're following the [Semver guide](https://semver.org/), so please check the website to see which number you'd need to increment.
+- Update the version number in the [manifest.json file](https://github.com/ClydeDz/hours-to-days-chrome-extension/blob/main/src/manifest.json#L5). We're following the [Semver guide](https://semver.org/), so please check the website to see which number you'd need to increment.
 - As a result of your changes, if you need to make changes to screenshots or description of the extension, please let me know in the description of your pull request and we can review your updated copy together. Updating this in the Chrome web store is currently a manual process.
 
 **Note:** Even after a successful build and deployment, the extension still remains in draft/unpublished state in the Chrome developer site. I need to manually submit a version for review which then eventually published the extension.

--- a/src/background.js
+++ b/src/background.js
@@ -73,7 +73,7 @@ function showTooltip(
         5
       : window.getSelection().getRangeAt(0).getBoundingClientRect().top +
         window.scrollY -
-        32;
+        50;
 
   tooltip.style.top = `${topPosition}px`;
 

--- a/src/background.js
+++ b/src/background.js
@@ -13,6 +13,7 @@ chrome.runtime.onInstalled.addListener(() => {
     id: CHROME_EXT_MENU_ID,
     title: "Convert hours to days",
     contexts: ["selection"],
+    documentUrlPatterns: ["https://*/*", "http://*/*", "file://*/*"],
   });
 });
 
@@ -22,6 +23,8 @@ chrome.action.onClicked.addListener(() => {
 
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId !== CHROME_EXT_MENU_ID) return;
+
+  if (tab.id === -1) return;
 
   chrome.storage.sync.get(
     [STORAGE_KEYS.HOURS_PER_DAY, STORAGE_KEYS.TOOLTIP_TIMEOUT],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Hours to Days",
   "description": "Convert hours to days by selecting text in a webpage.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Clyde D'Souza",
   "icons": {
     "16": "icons/icon16.png",

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -16,6 +16,7 @@
           id="hoursPerDayInput"
           name="hoursPerDayInput"
           min="1"
+          step="0.1"
           required
         />
         <label for="tooltipTimeoutInput">Tooltip timeout in seconds:</label>


### PR DESCRIPTION
## What has changed and why?
- Restrict which tabs and URLs this extension will work in
- Update the position of the tooltip
- Allow decimal places in hours per day field
- Uncomment deployment steps

## Does this fix an open issue? 
(If yes, please mention the number here)

## Type of change   
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist  
- [x] I have followed the [`CONTRIBUTING` document](https://github.com/ClydeDz/hours-to-days-chrome-extension/blob/main/docs/CONTRIBUTING.md) and have updated the required files.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] I've manually tested this change locally to ensure no errors appear.
